### PR TITLE
Soporte expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ await SDK.openImpression('impressionId');
 
 ## Push Notifications
 
+> Note for Expo Go users: Expo Go does not include the native Firebase Messaging module. As of this SDK version, Firebase messaging is loaded lazily and guarded, so importing the SDK features will work in Expo Go without crashing. Push-related methods will no-op if the native module is unavailable. To test or use push notifications, build a custom development client.
+
 ### Initialize Firebase
 
 Set up Firebase for push notifications:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gopersonal-react-native-sdk",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "",
   "main": "index.js",
   "types": "src/SDK.d.ts",


### PR DESCRIPTION
Dejo comentado el motivo del cambio: 
Si estamos usando expo go con ios, al usar la sdk se importan todos los módulos de la misma aunque no se usen. Expo go es incompatible con react-native-firebase y por lo tanto tira error. 
Para poder usar ios expo go con la sdk se tienen que resolver de forma dinámica los módulos no compatibles, incluso si no son usados por la app. En este caso, solo react-native-firebase. 
Por la manera de funcionar de Android solo se chequean los módulos que se van a usar y por lo tanto no da error, pero con ios sí.
